### PR TITLE
Changes in coffeescript 1.7.0 require register

### DIFF
--- a/bin/audiounitjs
+++ b/bin/audiounitjs
@@ -6,7 +6,7 @@ var optimist = require('optimist').usage('Create audio unit template with html u
             throw "You must provide the project configuration file.";
     });
     
-require('iced-coffee-script');
+require('iced-coffee-script/register');
 
 try {
   require('../lib/aujs')(optimist.argv._[0]);


### PR DESCRIPTION
audiounitjs fails with:

Error: Use CoffeeScript.register() or require the coffee-script/register module to require .iced.md files.

This fixes it.
